### PR TITLE
Update byte ordering in PlaceId format

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,28 @@
 
 **Geographic translation utilities for use on the Blockchain**: ( Longitude, Latitude )  <-> ( Block Place Id )
 
-**Author**: Ivyroot
+**Author**: Ivyroot https://warpcast.com/ivyroot
 
 **Description**:
 - Block Places are a set of ids that can be used to identify locations anywhere on Earth.
-- Each Block Place is a rectangular area whose sides are 1/100th of a degree long.
+- Each Block Place is a rectangular area with sides that are 1/100th of a degree long.
 - They are stored as Longitude, Latitude pairs encoded in a single number, the Block Place ID.
 
-**Details**:
-- The Longitude and Latitude values for a Block Place are stored as two parts:
-  - The first gives the non-decimal number, from 0-359 for Longitude and from 0-179 for Latitude.
-  - The second gives the decimal in hundredths of a degree (e.g., 0.00, 0.01, 0.02 ... 0.99).
+**Components**:
+- The Longitude and Latitude values for a Block Place are each stored as two parts:
+  - The first gives the whole number, from 0-359 for Longitude and from 0-179 for Latitude.
+  - The second gives the decimal in hundredths of a degree. So 0.00, 0.01, 0.02 ... 0.99 map to 0 through 99.
 
 **Bitpacking**:
 - The set of 4 values specifying a Block Place are bitpacked together into a single unique number:
-  - `lng` values must be less than 360: stored as 16 bits.
-  - `lat` values must be less than 180: stored as 8 bits.
-  - `lngDecimal` and `latDecimal` values must be less than 100: stored as 8 bits each.
+  - Longitude whole degree values must be less than 360. They are stored as 16 bits.
+  - Latitude whole degree values must be less than 180. They are stored as 8 bits.
+  - Decimal values must be less than 100. They are stored as 8 bits each.
+  - The byte ordering format is [Longitude][Latitude][Longitude Decimal][Latitude Decimal]
 
-**Translation to Coordinates**:
-- All values composing a BlockPlace are stored as unsigned (non-negative) values.
-- When coordinates are passed in they have an offset added to them.
-- When coordinates are passed out they have an offset subtracted from them.
+**Translation to Geographic Coordinates**:
+- All values composing a BlockPlace are stored as non-negative integers.
+- They are mapped to geographic coordinates using offsets that remove negative values.
+- When geographic coordinates are passed in they have an offset added to them.
+- When geographic coordinates are passed out they have an offset subtracted from them.
+- The offset is 180 for Longitude and 90 for Latitude.

--- a/src/BlockPlaces.sol
+++ b/src/BlockPlaces.sol
@@ -66,13 +66,10 @@ library BlockPlaces {
     // Bit packs 4 geo location uints together with the last two bits set to 1
     function placeIdFromLngLat(uint256 lng, uint256 lngDecimal, uint256 lat, uint256 latDecimal) public pure returns (uint256) {
         validateLngLat(lng, lngDecimal, lat, latDecimal);
-
         uint256 uint256_1 = lng << 26; // values < 360. use 16 bits
-        uint256 uint256_2 = lngDecimal << 18; // values < 100. use 8 bits
-        uint256 uint256_3 = lat << 10; // values < 180. use 8 bits
+        uint256 uint256_2 = lat << 18; // values < 180. use 8 bits
+        uint256 uint256_3 = lngDecimal << 10; // values < 100. use 8 bits
         uint256 uint256_4 = latDecimal << 2; // values < 100. use 8 bits
-
-        // Return the bit packed uint256 with the last two bits set to 1 to ensure it's never 0.
         uint256 patternCode = uint256_1 | uint256_2 | uint256_3 | uint256_4;
         return patternCode | 3;  // Ensuring the last two bits are 1
     }
@@ -85,14 +82,14 @@ library BlockPlaces {
         }
 
         // Ensure there is not extra bits in front
-        if (_placeId > 24118218127) {
+        if (_placeId > 24139107727) {
             return(false, 0, 0, 0, 0);
         }
 
         // Shift the values out of the correct positions
         uint16 lngSrc = uint16(_placeId >> 26);
-        uint8 lngDecimalSrc = uint8(_placeId >> 18);
-        uint8 latSrc = uint8(_placeId >> 10);
+        uint8 latSrc = uint8(_placeId >> 18);
+        uint8 lngDecimalSrc = uint8(_placeId >> 10);
         uint8 latDecimalSrc = uint8(_placeId >> 2);
         if (isValidLngLat(lngSrc, lngDecimalSrc, latSrc, latDecimalSrc) > 0) {
             return(false, 0, 0, 0, 0);

--- a/test/BlockPlaces.t.sol
+++ b/test/BlockPlaces.t.sol
@@ -30,11 +30,11 @@ contract BlockPlacesTest is Test {
     // test location all max values
     function testEncodeLocationMax() public {
         uint testResult = BlockPlaces.placeIdFromLngLat(359, 99, 179, 99);
-        assertEq(testResult, 24118218127);
+        assertEq(testResult, 24139107727);
     }
 
     function testDecodeLocationMax() public {
-        (bool found, uint long, uint longOffset, uint lat, uint latOffset) = BlockPlaces.lngLatFromPlaceId(24118218127);
+        (bool found, uint long, uint longOffset, uint lat, uint latOffset) = BlockPlaces.lngLatFromPlaceId(24139107727);
         assertEq(found, true);
         assertEq(long, 359);
         assertEq(longOffset, 99);
@@ -43,7 +43,7 @@ contract BlockPlacesTest is Test {
     }
 
     function testCannotDecodeAboveLocationMax() public {
-        (bool found,,,,) = BlockPlaces.lngLatFromPlaceId(24118218127 + 1);
+        (bool found,,,,) = BlockPlaces.lngLatFromPlaceId(24139107727 + 1);
         assertEq(found, false);
     }
 
@@ -53,14 +53,22 @@ contract BlockPlacesTest is Test {
         assertEq(found, false);
     }
 
+    // test location with just leftmost component set
+    function testEncodeLocationLongitudeOnly() public {
+        uint testResult = BlockPlaces.placeIdFromLngLat(359, 0, 0, 0);
+        assertEq(testResult, 24092082179);
+        uint16 longitudeComponent = uint16(testResult >> 26);
+        assertEq(longitudeComponent, 359);
+    }
+
     function testEncodeLocation1() public {
         // hollywood sign
         uint testResult = BlockPlaces.placeIdFromLngLat(118, 32, 34, 14);
-        assertEq(testResult, 7927269435);
+        assertEq(testResult, 7927791675);
     }
 
     function testDecodeLocation1() public {
-        (bool found, uint long, uint longOffset, uint lat, uint latOffset) = BlockPlaces.lngLatFromPlaceId(7927269435);
+        (bool found, uint long, uint longOffset, uint lat, uint latOffset) = BlockPlaces.lngLatFromPlaceId(7927791675);
         assertEq(found, true);
         assertEq(long, 118);
         assertEq(longOffset, 32);

--- a/typescript/src/BlockPlaces.ts
+++ b/typescript/src/BlockPlaces.ts
@@ -42,8 +42,8 @@ export class BlockPlaces {
         this.validateBlockPlace(location);
         const { lng, lngDecimal, lat, latDecimal } = location;
         const uint256_1 = BigInt(lng) << BigInt(26);
-        const uint256_2 = BigInt(lngDecimal) << BigInt(18);
-        const uint256_3 = BigInt(lat) << BigInt(10);
+        const uint256_2 = BigInt(lat) << BigInt(18);
+        const uint256_3 = BigInt(lngDecimal) << BigInt(10);
         const uint256_4 = BigInt(latDecimal) << BigInt(2);
         const patternCode = uint256_1 | uint256_2 | uint256_3 | uint256_4;
         return Number(patternCode | BigInt(3)); // Ensuring the last two bits are 1
@@ -51,12 +51,12 @@ export class BlockPlaces {
 
     static blockPlaceFromPlaceId(placeId: PlaceId): BlockPlace | null {
         const bigPlaceId = BigInt(placeId);
-        if (bigPlaceId < 3 || bigPlaceId > BigInt(24118218127)) {
+        if (bigPlaceId < 3 || bigPlaceId > BigInt(24139107727)) {
             return null;
         }
         const lngSrc = (bigPlaceId >> BigInt(26)) & BigInt(0xFFFF);
-        const lngDecimalSrc = (bigPlaceId >> BigInt(18)) & BigInt(0xFF);
-        const latSrc = (bigPlaceId >> BigInt(10)) & BigInt(0xFF);
+        const latSrc = (bigPlaceId >> BigInt(18)) & BigInt(0xFF);
+        const lngDecimalSrc = (bigPlaceId >> BigInt(10)) & BigInt(0xFF);
         const latDecimalSrc = (bigPlaceId >> BigInt(2)) & BigInt(0xFF);
         const blockPlace = {
             lng: Number(lngSrc),

--- a/typescript/test/BlockPlaces.test.ts
+++ b/typescript/test/BlockPlaces.test.ts
@@ -35,7 +35,7 @@ describe('BlockPlaces.validateBlockPlace', () => {
 describe('BlockPlaces.enclosingPlaceIdForPoint', () => {
   it('should return the correct PlaceId for a given point', () => {
     const point = new LngLat(100, 50);
-    const expectedPlaceId = 18790625283;
+    const expectedPlaceId = 18827182083;
     expect(BlockPlaces.enclosingPlaceIdForPoint(point)).toBe(expectedPlaceId);
   });
 


### PR DESCRIPTION
This PR switches the byte ordering in the format so that the first bits (ie the leftmost bits) are the whole number Longitude and Latitude of the Block Place. This re-arrangement allows for easy filtering and grouping of PlaceIDs based on the leftmost bits since those bits now identify a 1 degree X 1 degree region. This is an area of about 55x70 miles so is a good  bucket for grouping Block Places. 